### PR TITLE
Improve zooming for mobile

### DIFF
--- a/src/components/Map.vue
+++ b/src/components/Map.vue
@@ -73,8 +73,8 @@ export default {
    */
   async mounted() {
     this.map = L.map("map", {
-      scrollWheelZoom: false,
-      minZoom: 12,
+      scrollWheelZoom: true,
+      minZoom: 10,
       doubleClickZoom: false,
       zoomControl: false,
     }).setView(this.viennaCoordinates, 12);


### PR DESCRIPTION
Sets the minimum zoom limit to 10 and enables zooming by scrolling.